### PR TITLE
[DNM] Adds CI to Handle Duplicate Proc Definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           python tools/ci/no_duplicate_definitions.py
           python tools/ci/check_icons.py
           python tools/ci/check_random_spawner_prefabs.py
+          python tools/ci/check_duplicate_procs.py
           python -m tools.ci.check_map_sizes
           python -m tools.ci.check_legacy_attack_chain
           python -m tools.maplint.source --github

--- a/tools/ci/check_duplicate_procs.py
+++ b/tools/ci/check_duplicate_procs.py
@@ -1,0 +1,33 @@
+import re
+from collections import defaultdict
+from pathlib import Path
+
+proc_definitions = defaultdict(list)
+
+for file in Path(".").glob("**/*.dm"):
+    with open(file, 'r', encoding='utf-8', errors='ignore') as f:
+        for line_num, line in enumerate(f, 1):
+            if match := re.match(r"^(/[\w/]+/[\w]+)\(\)$", line.strip()):
+                proc_path = match.group(1)
+                proc_definitions[proc_path].append((file, line_num))
+
+def main():
+    alert_sent = False
+    for proc_path, locations in proc_definitions.items():
+        if len(locations) > 1:
+            if not alert_sent:
+                print("The following proc definitions are duplicated. Please fix!\n")
+                alert_sent = True
+
+            print(f">>> {proc_path}()")
+            for file, line_num in locations:
+                print(f"{file}:{line_num}")
+            print()
+
+    if alert_sent:
+        exit(1)
+    else:
+        exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

## What Does This PR Do
Creates CI to catch duplicate proc definitions.
## Why It's Good For The Game
Produces clean code and prevents unwanted behavior when making changes.
## Testing
Tested while making the follow fix PRs:
https://github.com/ParadiseSS13/Paradise/pull/29883
https://github.com/ParadiseSS13/Paradise/pull/29882
https://github.com/ParadiseSS13/Paradise/pull/29881
https://github.com/ParadiseSS13/Paradise/pull/29880
https://github.com/ParadiseSS13/Paradise/pull/29879
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
NPFC
